### PR TITLE
Fix compat feature, add recommendations for allowing use in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ By configuring Tokio with a barrier to rendezvous worker threads during shutdown
 
 The optimization that this crate provides require that the [async_local::main](https://docs.rs/async-local/latest/async_local/attr.main.html) or [async_local::test](https://docs.rs/async-local/latest/async_local/attr.test.html) macro be used to configure the Tokio runtime. This is enforced by a pre-main check that asserts [async_local::main](https://docs.rs/async-local/latest/async_local/attr.main.html) has been used.
 
+## Tests
+
+Running tests requires the `compat` feature. To enable the feature just for your development environment, add the crate with this feature to your `dev-dependencies` in `Cargo.toml`:
+
+```toml
+[dependencies]
+async-local = "6.0.1"
+
+[dev-dependencies]
+async-local = { version = "6.0.1", features = ["compat"] }
+```
+
 ## Compatibility Mode
 
 Enabling the `compat` feature flag will allow this crate to be used with any runtime configuration by disabling the performance optimization this crate provides and instead internally using `std::sync::Arc`

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -212,12 +212,13 @@ impl Runtime {
 #[distributed_slice]
 pub static RUNTIMES: [bool];
 
+#[cfg(not(feature = "compat"))]
 #[cfg(not(test))]
 #[ctor::ctor]
 fn assert_runtime_configured() {
   if RUNTIMES.ne(&[true]) {
     panic!(
-      "The #[async_local::main] macro must be used to configure the Tokio runtime for use with the `async-local` crate. For compatibilty with other async runtime configurations, the `compat` feature can be used to disable the optimizations this crate provides"
+      "The #[async_local::main] macro must be used to configure the Tokio runtime for use with the `async-local` crate. For compatibilty with other async runtime configurations, the `compat` feature can be used to disable the optimizations this crate provides.  This feature must be enable for tests."
     );
   }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -218,7 +218,7 @@ pub static RUNTIMES: [bool];
 fn assert_runtime_configured() {
   if RUNTIMES.ne(&[true]) {
     panic!(
-      "The #[async_local::main] macro must be used to configure the Tokio runtime for use with the `async-local` crate. For compatibilty with other async runtime configurations, the `compat` feature can be used to disable the optimizations this crate provides.  This feature must be enable for tests."
+      "The #[async_local::main] macro must be used to configure the Tokio runtime for use with the `async-local` crate. For compatibilty with other async runtime configurations, the `compat` feature can be used to disable the optimizations this crate provides.  This feature must be enabled for tests."
     );
   }
 }


### PR DESCRIPTION
Noticed some pretty major issues with the runtime check.
For one its not disable when using the compat feature, so the compat feature doesn't work.
Secondly #[cfg(not(test))] only applies to the current crate, not its dependencies, so the check would still run for tests on other creates.
This PR fixes the first issue, and adds recommendations to the README and runtime check error message to try and address the second issue.

P.S. your repo is still on v5.0.1